### PR TITLE
- Flyttet felles input fra delberegningene til toppnivået

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnbarnebidrag.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnbarnebidrag.kt
@@ -2,17 +2,107 @@ package no.nav.bidrag.beregn.barnebidrag.rest.dto.http
 
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
+import no.nav.bidrag.beregn.barnebidrag.rest.exception.UgyldigInputException
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadGrunnlagCore
+import no.nav.bidrag.beregn.nettobarnetilsyn.dto.BeregnNettoBarnetilsynGrunnlagCore
+import no.nav.bidrag.beregn.samvaersfradrag.dto.BeregnSamvaersfradragGrunnlagCore
+import no.nav.bidrag.beregn.underholdskostnad.dto.BeregnUnderholdskostnadGrunnlagCore
+import java.time.LocalDate
 
 // Grunnlag
 @ApiModel(value = "Grunnlaget for en barnebidragsberegning")
 data class BeregnBarnebidragGrunnlag(
+    @ApiModelProperty(value = "Beregn fra-dato") var beregnDatoFra: LocalDate? = null,
+    @ApiModelProperty(value = "Beregn til-dato") var beregnDatoTil: LocalDate? = null,
+    @ApiModelProperty(value = "Søknadsbarnets fødselsdato") var soknadBarnFodselsdato: LocalDate? = null,
+    @ApiModelProperty(value = "Søknadsbarnets person-id") var soknadBarnPersonId: Int? = null,
     @ApiModelProperty(value = "Beregn bidragsevne grunnlag") var beregnBidragsevneGrunnlag: BeregnBidragsevneGrunnlag? = null,
     @ApiModelProperty(value = "Beregn netto barnetilsyn grunnlag") var beregnNettoBarnetilsynGrunnlag: BeregnNettoBarnetilsynGrunnlag? = null,
     @ApiModelProperty(value = "Beregn underholdskostnad grunnlag") var beregnUnderholdskostnadGrunnlag: BeregnUnderholdskostnadGrunnlag? = null,
     @ApiModelProperty(
         value = "Beregn BPs andel av underholdskostnad grunnlag") var beregnBPAndelUnderholdskostnadGrunnlag: BeregnBPsAndelUnderholdskostnadGrunnlag? = null,
     @ApiModelProperty(value = "Beregn samværsfradrag grunnlag") var beregnSamvaersfradragGrunnlag: BeregnSamvaersfradragGrunnlag? = null
-)
+) {
+
+  fun validerBarnebidragGrunnlag() {
+    if (beregnDatoFra != null) beregnDatoFra!! else throw UgyldigInputException("beregnDatoFra kan ikke være null")
+    if (beregnDatoTil != null) beregnDatoTil!! else throw UgyldigInputException("beregnDatoTil kan ikke være null")
+    if (soknadBarnFodselsdato != null) soknadBarnFodselsdato!! else throw UgyldigInputException("soknadBarnFodselsdato kan ikke være null")
+    if (soknadBarnPersonId != null) soknadBarnPersonId!! else throw UgyldigInputException("soknadBarnPersonId kan ikke være null")
+
+    if (beregnBidragsevneGrunnlag != null) beregnBidragsevneGrunnlag!!
+    else throw UgyldigInputException("beregnBidragsevneGrunnlag kan ikke være null")
+
+    if (beregnNettoBarnetilsynGrunnlag != null) beregnNettoBarnetilsynGrunnlag!!
+    else throw UgyldigInputException("beregnNettoBarnetilsynGrunnlag kan ikke være null")
+
+    if (beregnUnderholdskostnadGrunnlag != null) beregnUnderholdskostnadGrunnlag!!
+    else throw UgyldigInputException("beregnUnderholdskostnadGrunnlag kan ikke være null")
+
+    if (beregnBPAndelUnderholdskostnadGrunnlag != null) beregnBPAndelUnderholdskostnadGrunnlag!!
+    else throw UgyldigInputException("beregnBPAndelUnderholdskostnadGrunnlag kan ikke være null")
+
+    if (beregnSamvaersfradragGrunnlag != null) beregnSamvaersfradragGrunnlag!!
+    else throw UgyldigInputException("beregnSamvaersfradragGrunnlag kan ikke være null")
+  }
+
+  fun nettoBarnetilsynTilCore() = BeregnNettoBarnetilsynGrunnlagCore(
+      beregnDatoFra = beregnDatoFra!!,
+      beregnDatoTil = beregnDatoTil!!,
+
+      faktiskUtgiftPeriodeListe =
+      if (beregnNettoBarnetilsynGrunnlag!!.faktiskUtgiftPeriodeListe != null)
+        beregnNettoBarnetilsynGrunnlag!!.faktiskUtgiftPeriodeListe!!.map { it.tilCore() }
+      else throw UgyldigInputException("faktiskUtgiftPeriodeListe kan ikke være null"),
+
+      sjablonPeriodeListe = emptyList()
+  )
+
+  fun underholdskostnadTilCore() = BeregnUnderholdskostnadGrunnlagCore(
+      beregnDatoFra = beregnDatoFra!!,
+      beregnDatoTil = beregnDatoTil!!,
+      soknadBarnFodselsdato = soknadBarnFodselsdato!!,
+
+      barnetilsynMedStonadPeriodeListe =
+      if (beregnUnderholdskostnadGrunnlag!!.barnetilsynMedStonadPeriodeListe != null)
+        beregnUnderholdskostnadGrunnlag!!.barnetilsynMedStonadPeriodeListe!!.map { it.tilCore() }
+      else throw UgyldigInputException("barnetilsynMedStonadPeriodeListe kan ikke være null"),
+
+      nettoBarnetilsynPeriodeListe = emptyList(),
+
+      forpleiningUtgiftPeriodeListe =
+      if (beregnUnderholdskostnadGrunnlag!!.forpleiningUtgiftPeriodeListe != null)
+        beregnUnderholdskostnadGrunnlag!!.forpleiningUtgiftPeriodeListe!!.map { it.tilCore() }
+      else throw UgyldigInputException("forpleiningUtgiftPeriodeListe kan ikke være null"),
+
+      sjablonPeriodeListe = emptyList()
+  )
+
+  fun bpAndelUnderholdskostnadTilCore() = BeregnBPsAndelUnderholdskostnadGrunnlagCore(
+      beregnDatoFra = beregnDatoFra!!,
+      beregnDatoTil = beregnDatoTil!!,
+
+      inntekterPeriodeListe =
+      if (beregnBPAndelUnderholdskostnadGrunnlag!!.inntekterPeriodeListe != null)
+        beregnBPAndelUnderholdskostnadGrunnlag!!.inntekterPeriodeListe!!.map { it.tilCore() }
+      else throw UgyldigInputException("inntekterPeriodeListe kan ikke være null"),
+
+      sjablonPeriodeListe = emptyList()
+  )
+
+  fun samvaersfradragTilCore() = BeregnSamvaersfradragGrunnlagCore(
+      beregnDatoFra = beregnDatoFra!!,
+      beregnDatoTil = beregnDatoTil!!,
+      soknadsbarnFodselsdato = soknadBarnFodselsdato!!,
+
+      samvaersklassePeriodeListe =
+      if (beregnSamvaersfradragGrunnlag!!.samvaersklassePeriodeListe != null)
+        beregnSamvaersfradragGrunnlag!!.samvaersklassePeriodeListe!!.map { it.tilCore() }
+      else throw UgyldigInputException("samvaersklassePeriodeListe kan ikke være null"),
+
+      sjablonPeriodeListe = emptyList()
+  )
+}
 
 // Resultat
 @ApiModel(value = "Resultatet av en barnebidragsberegning")

--- a/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnbpandelunderholdskostnad.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnbpandelunderholdskostnad.kt
@@ -3,32 +3,17 @@ package no.nav.bidrag.beregn.barnebidrag.rest.dto.http
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import no.nav.bidrag.beregn.barnebidrag.rest.exception.UgyldigInputException
-import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadGrunnlagCore
 import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadResultatCore
 import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.InntekterPeriodeCore
 import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.ResultatBeregningCore
 import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.ResultatGrunnlagCore
 import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.ResultatPeriodeCore
-import java.time.LocalDate
 
 // Grunnlag
 @ApiModel(value = "Grunnlaget for en beregning av BPs andel av underholdskostnad")
 data class BeregnBPsAndelUnderholdskostnadGrunnlag(
-    @ApiModelProperty(value = "Beregn BPs andel underholdskostnad fra-dato") var beregnDatoFra: LocalDate? = null,
-    @ApiModelProperty(value = "Beregn BPs andel underholdskostnad til-dato") var beregnDatoTil: LocalDate? = null,
     @ApiModelProperty(value = "Periodisert liste over inntekter") val inntekterPeriodeListe: List<InntekterPeriode>? = null
-) {
-
-  fun tilCore() = BeregnBPsAndelUnderholdskostnadGrunnlagCore(
-      beregnDatoFra = if (beregnDatoFra != null) beregnDatoFra!! else throw UgyldigInputException("beregnDatoFra kan ikke være null"),
-      beregnDatoTil = if (beregnDatoTil != null) beregnDatoTil!! else throw UgyldigInputException("beregnDatoTil kan ikke være null"),
-
-      inntekterPeriodeListe = if (inntekterPeriodeListe != null) inntekterPeriodeListe.map { it.tilCore() }
-      else throw UgyldigInputException("inntekterPeriodeListe kan ikke være null"),
-
-      sjablonPeriodeListe = emptyList()
-  )
-}
+)
 
 @ApiModel(value = "Inntekter")
 data class InntekterPeriode(
@@ -90,13 +75,13 @@ data class ResultatGrunnlagBPsAndelUnderholdskostnad(
     @ApiModelProperty(value = "Inntekt bidragspliktig") var inntektBP: Double? = null,
     @ApiModelProperty(value = "Inntekt bidragsmottaker") var inntektBM: Double? = null,
     @ApiModelProperty(value = "Inntekt bidragsbarn") var inntektBB: Double? = null,
-    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
+//    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
 ) {
 
   constructor(resultatGrunnlag: ResultatGrunnlagCore) : this(
       inntektBP = resultatGrunnlag.inntektBP,
       inntektBM = resultatGrunnlag.inntektBM,
       inntektBB = resultatGrunnlag.inntektBB,
-      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
+//      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
   )
 }

--- a/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnnettobarnetilsyn.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnnettobarnetilsyn.kt
@@ -3,7 +3,6 @@ package no.nav.bidrag.beregn.barnebidrag.rest.dto.http
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import no.nav.bidrag.beregn.barnebidrag.rest.exception.UgyldigInputException
-import no.nav.bidrag.beregn.nettobarnetilsyn.dto.BeregnNettoBarnetilsynGrunnlagCore
 import no.nav.bidrag.beregn.nettobarnetilsyn.dto.BeregnNettoBarnetilsynResultatCore
 import no.nav.bidrag.beregn.nettobarnetilsyn.dto.FaktiskUtgiftCore
 import no.nav.bidrag.beregn.nettobarnetilsyn.dto.FaktiskUtgiftPeriodeCore
@@ -15,22 +14,9 @@ import java.time.LocalDate
 // Grunnlag
 @ApiModel(value = "Grunnlaget for en netto barnetilsyn beregning")
 data class BeregnNettoBarnetilsynGrunnlag(
-    @ApiModelProperty(value = "Beregn netto barnetilsyn fra-dato") var beregnDatoFra: LocalDate? = null,
-    @ApiModelProperty(value = "Beregn netto barnetilsyn til-dato") var beregnDatoTil: LocalDate? = null,
     @ApiModelProperty(
         value = "Periodisert liste over bidragsmottakers faktiske bruttoutgifter til tilsyn") val faktiskUtgiftPeriodeListe: List<FaktiskUtgiftPeriode>? = null
-) {
-
-  fun tilCore() = BeregnNettoBarnetilsynGrunnlagCore(
-      beregnDatoFra = if (beregnDatoFra != null) beregnDatoFra!! else throw UgyldigInputException("beregnDatoFra kan ikke være null"),
-      beregnDatoTil = if (beregnDatoTil != null) beregnDatoTil!! else throw UgyldigInputException("beregnDatoTil kan ikke være null"),
-
-      faktiskUtgiftPeriodeListe = if (faktiskUtgiftPeriodeListe != null) faktiskUtgiftPeriodeListe.map { it.tilCore() } else throw UgyldigInputException(
-          "faktiskUtgiftPeriodeListe kan ikke være null"),
-
-      sjablonPeriodeListe = emptyList()
-  )
-}
+)
 
 @ApiModel(value = "Bidragsmottakers faktiske bruttoutgifter til tilsyn")
 data class FaktiskUtgiftPeriode(
@@ -60,7 +46,8 @@ data class BeregnNettoBarnetilsynResultat(
 ) {
 
   constructor(beregnNettoBarnetilsynResultat: BeregnNettoBarnetilsynResultatCore) : this(
-      resultatPeriodeListe = beregnNettoBarnetilsynResultat.resultatPeriodeListe.map {ResultatPeriodeNettoBarnetilsyn(it)
+      resultatPeriodeListe = beregnNettoBarnetilsynResultat.resultatPeriodeListe.map {
+        ResultatPeriodeNettoBarnetilsyn(it)
       }
   )
 }
@@ -93,13 +80,14 @@ data class ResultatBeregningNettoBarnetilsyn(
 
 @ApiModel(value = "Grunnlaget for beregning av netto barnetilsyn")
 data class ResultatGrunnlagNettoBarnetilsyn(
-    @ApiModelProperty(value = "Liste over faktiske utgifter") var resultatGrunnlagFaktiskUtgiftListe: List<ResultatGrunnlagFaktiskUtgift> = emptyList(),
-    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
+    @ApiModelProperty(
+        value = "Liste over faktiske utgifter") var resultatGrunnlagFaktiskUtgiftListe: List<ResultatGrunnlagFaktiskUtgift> = emptyList(),
+//    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
 ) {
 
   constructor(resultatGrunnlag: ResultatGrunnlagCore) : this(
       resultatGrunnlagFaktiskUtgiftListe = resultatGrunnlag.faktiskUtgiftListe.map { ResultatGrunnlagFaktiskUtgift(it) },
-      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
+//      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
   )
 }
 

--- a/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnsamvaersfradrag.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnsamvaersfradrag.kt
@@ -3,36 +3,18 @@ package no.nav.bidrag.beregn.barnebidrag.rest.dto.http
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import no.nav.bidrag.beregn.barnebidrag.rest.exception.UgyldigInputException
-import no.nav.bidrag.beregn.samvaersfradrag.dto.BeregnSamvaersfradragGrunnlagCore
 import no.nav.bidrag.beregn.samvaersfradrag.dto.BeregnSamvaersfradragResultatCore
 import no.nav.bidrag.beregn.samvaersfradrag.dto.ResultatBeregningCore
 import no.nav.bidrag.beregn.samvaersfradrag.dto.ResultatGrunnlagCore
 import no.nav.bidrag.beregn.samvaersfradrag.dto.ResultatPeriodeCore
 import no.nav.bidrag.beregn.samvaersfradrag.dto.SamvaersklassePeriodeCore
-import java.time.LocalDate
 
 // Grunnlag
 @ApiModel(value = "Grunnlaget for en samværsfradragberegning")
 data class BeregnSamvaersfradragGrunnlag(
-    @ApiModelProperty(value = "Beregn samværsfradrag fra-dato") var beregnDatoFra: LocalDate? = null,
-    @ApiModelProperty(value = "Beregn samværsfradrag til-dato") var beregnDatoTil: LocalDate? = null,
-    @ApiModelProperty(value = "Søknadsbarnets fødselsdato") var soknadsbarnFodselsdato: LocalDate? = null,
     @ApiModelProperty(
         value = "Periodisert liste over bidragspliktiges samværsklasser") val samvaersklassePeriodeListe: List<SamvaersklassePeriode>? = null
-) {
-
-  fun tilCore() = BeregnSamvaersfradragGrunnlagCore(
-      beregnDatoFra = if (beregnDatoFra != null) beregnDatoFra!! else throw UgyldigInputException("beregnDatoFra kan ikke være null"),
-      beregnDatoTil = if (beregnDatoTil != null) beregnDatoTil!! else throw UgyldigInputException("beregnDatoTil kan ikke være null"),
-      soknadsbarnFodselsdato = if (soknadsbarnFodselsdato != null) soknadsbarnFodselsdato!! else throw UgyldigInputException(
-          "soknadsbarnFodselsdato kan ikke være null"),
-
-      samvaersklassePeriodeListe = if (samvaersklassePeriodeListe != null) samvaersklassePeriodeListe.map { it.tilCore() }
-      else throw UgyldigInputException("samvaersklassePeriodeListe kan ikke være null"),
-
-      sjablonPeriodeListe = emptyList()
-  )
-}
+)
 
 @ApiModel(value = "Bidragspliktiges samværsklasse")
 data class SamvaersklassePeriode(
@@ -89,12 +71,12 @@ data class ResultatBeregningSamvaersfradrag(
 data class ResultatGrunnlagSamvaersfradrag(
     @ApiModelProperty(value = "Søknadsbarnets alder") var soknadBarnAlder: Int? = null,
     @ApiModelProperty(value = "Samværsklasse") var samvaersklasse: String? = null,
-    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
+//    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
 ) {
 
   constructor(resultatGrunnlag: ResultatGrunnlagCore) : this(
       soknadBarnAlder = resultatGrunnlag.soknadBarnAlder,
       samvaersklasse = resultatGrunnlag.samvaersklasse,
-      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
+//      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
   )
 }

--- a/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnunderholdskostnad.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/barnebidrag/rest/dto/http/beregnunderholdskostnad.kt
@@ -3,49 +3,21 @@ package no.nav.bidrag.beregn.barnebidrag.rest.dto.http
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
 import no.nav.bidrag.beregn.barnebidrag.rest.exception.UgyldigInputException
-import no.nav.bidrag.beregn.felles.dto.PeriodeCore
 import no.nav.bidrag.beregn.underholdskostnad.dto.BarnetilsynMedStonadPeriodeCore
-import no.nav.bidrag.beregn.underholdskostnad.dto.BeregnUnderholdskostnadGrunnlagCore
 import no.nav.bidrag.beregn.underholdskostnad.dto.BeregnUnderholdskostnadResultatCore
 import no.nav.bidrag.beregn.underholdskostnad.dto.ForpleiningUtgiftPeriodeCore
-import no.nav.bidrag.beregn.underholdskostnad.dto.NettoBarnetilsynPeriodeCore
 import no.nav.bidrag.beregn.underholdskostnad.dto.ResultatBeregningCore
 import no.nav.bidrag.beregn.underholdskostnad.dto.ResultatGrunnlagCore
 import no.nav.bidrag.beregn.underholdskostnad.dto.ResultatPeriodeCore
-import java.time.LocalDate
-import java.util.Collections.singletonList
 
 // Grunnlag
 @ApiModel(value = "Grunnlaget for en underholdskostnadberegning")
 data class BeregnUnderholdskostnadGrunnlag(
-    @ApiModelProperty(value = "Beregn underholdskostnad fra-dato") var beregnDatoFra: LocalDate? = null,
-    @ApiModelProperty(value = "Beregn underholdskostnad til-dato") var beregnDatoTil: LocalDate? = null,
-    @ApiModelProperty(value = "Søknadsbarnets fødselsdato") var soknadBarnFodselsdato: LocalDate? = null,
     @ApiModelProperty(
         value = "Periodisert liste over bidragsmottakers barnetilsyn med stønad") val barnetilsynMedStonadPeriodeListe: List<BarnetilsynMedStonadPeriode>? = null,
     @ApiModelProperty(
         value = "Periodisert liste over bidragsmottakers utgifter til forpleining") val forpleiningUtgiftPeriodeListe: List<ForpleiningUtgiftPeriode>? = null
-) {
-
-  fun tilCore() = BeregnUnderholdskostnadGrunnlagCore(
-      beregnDatoFra = if (beregnDatoFra != null) beregnDatoFra!! else throw UgyldigInputException("beregnDatoFra kan ikke være null"),
-      beregnDatoTil = if (beregnDatoTil != null) beregnDatoTil!! else throw UgyldigInputException("beregnDatoTil kan ikke være null"),
-      soknadBarnFodselsdato = if (soknadBarnFodselsdato != null) soknadBarnFodselsdato!! else throw UgyldigInputException(
-          "soknadBarnFodselsdato kan ikke være null"),
-
-      barnetilsynMedStonadPeriodeListe = if (barnetilsynMedStonadPeriodeListe != null) barnetilsynMedStonadPeriodeListe.map { it.tilCore() }
-      else throw UgyldigInputException("barnetilsynMedStonadPeriodeListe kan ikke være null"),
-
-      //TODO Endre til emptyList
-      nettoBarnetilsynPeriodeListe = singletonList(
-          NettoBarnetilsynPeriodeCore(PeriodeCore(LocalDate.parse("2019-07-01"), LocalDate.parse("2020-01-01")), 1000.0)),
-
-      forpleiningUtgiftPeriodeListe = if (forpleiningUtgiftPeriodeListe != null) forpleiningUtgiftPeriodeListe.map { it.tilCore() }
-      else throw UgyldigInputException("forpleiningUtgiftPeriodeListe kan ikke være null"),
-
-      sjablonPeriodeListe = emptyList()
-  )
-}
+)
 
 @ApiModel(value = "Bidragsmottakers barnetilsyn med stønad")
 data class BarnetilsynMedStonadPeriode(
@@ -121,7 +93,7 @@ data class ResultatGrunnlagUnderholdskostnad(
     @ApiModelProperty(value = "Barnetilsyn med stønad - stønad-type") var barnetilsynMedStonadStonadType: String? = null,
     @ApiModelProperty(value = "Faktisk utgift barnetilsyn - netto-beløp") var nettoBarnetilsynBelop: Double? = null,
     @ApiModelProperty(value = "Utgift forpleining - beløp") var forpleiningUtgiftBelop: Double? = null,
-    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
+//    @ApiModelProperty(value = "Liste over sjablonperioder") var sjablonListe: List<Sjablon> = emptyList()
 ) {
 
   constructor(resultatGrunnlag: ResultatGrunnlagCore) : this(
@@ -130,6 +102,6 @@ data class ResultatGrunnlagUnderholdskostnad(
       barnetilsynMedStonadStonadType = resultatGrunnlag.barnetilsynMedStonadStonadType,
       nettoBarnetilsynBelop = resultatGrunnlag.nettoBarnetilsynBelop,
       forpleiningUtgiftBelop = resultatGrunnlag.forpleiningUtgiftBelop,
-      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
+//      sjablonListe = resultatGrunnlag.sjablonListe.map { Sjablon(it) }
   )
 }

--- a/src/test/java/no/nav/bidrag/beregn/barnebidrag/rest/TestUtil.java
+++ b/src/test/java/no/nav/bidrag/beregn/barnebidrag/rest/TestUtil.java
@@ -70,12 +70,69 @@ import no.nav.bidrag.beregn.underholdskostnad.dto.BeregnUnderholdskostnadResulta
 
 public class TestUtil {
 
-
+  // Barnebidrag
   public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlag() {
-    return new BeregnBarnebidragGrunnlag(byggBidragsevneGrunnlag(""), byggNettoBarnetilsynGrunnlag(""), byggUnderholdskostnadGrunnlag(""),
-        byggBPsAndelUnderholdskostnadGrunnlag(""), byggSamvaersfradragGrunnlag(""));
+    return byggBarnebidragGrunnlag("");
   }
 
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenBeregnDatoFra() {
+    return byggBarnebidragGrunnlag("beregnDatoFra");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenBeregnDatoTil() {
+    return byggBarnebidragGrunnlag("beregnDatoTil");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenSoknadBarnFodselsdato() {
+    return byggBarnebidragGrunnlag("soknadBarnFodselsdato");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenSoknadBarnPersonId() {
+    return byggBarnebidragGrunnlag("soknadBarnPersonId");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenBeregnBidragsevneGrunnlag() {
+    return byggBarnebidragGrunnlag("beregnBidragsevneGrunnlag");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenBeregnNettoBarnetilsynGrunnlag() {
+    return byggBarnebidragGrunnlag("beregnNettoBarnetilsynGrunnlag");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenBeregnUnderholdskostnadGrunnlag() {
+    return byggBarnebidragGrunnlag("beregnUnderholdskostnadGrunnlag");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenBeregnBPAndelUnderholdskostnadGrunnlag() {
+    return byggBarnebidragGrunnlag("beregnBPAndelUnderholdskostnadGrunnlag");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlagUtenBeregnSamvaersfradragGrunnlag() {
+    return byggBarnebidragGrunnlag("beregnSamvaersfradragGrunnlag");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeListe() {
+    return byggBarnebidragGrunnlag("", "" ,"faktiskUtgiftPeriodeListe", "", "", "");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeListe() {
+    return byggBarnebidragGrunnlag("", "", "", "barnetilsynMedStonadPeriodeListe", "", "");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeListe() {
+    return byggBarnebidragGrunnlag("", "", "", "forpleiningUtgiftPeriodeListe", "", "");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeListe() {
+    return byggBarnebidragGrunnlag("", "", "", "", "inntekterPeriodeListe", "");
+  }
+
+  public static BeregnBarnebidragGrunnlag byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeListe() {
+    return byggBarnebidragGrunnlag("", "", "", "", "", "samvaersklassePeriodeListe");
+  }
+
+
+  // Bidragsevne
   public static BeregnBidragsevneGrunnlag byggBidragsevneGrunnlag() {
     return byggBidragsevneGrunnlag("");
   }
@@ -84,18 +141,8 @@ public class TestUtil {
     return byggNettoBarnetilsynGrunnlag("");
   }
 
-  public static BeregnNettoBarnetilsynGrunnlag byggNettoBarnetilsynGrunnlagUtenBeregnDatoFra() {
-    return byggNettoBarnetilsynGrunnlag("beregnDatoFra");
-  }
 
-  public static BeregnNettoBarnetilsynGrunnlag byggNettoBarnetilsynGrunnlagUtenBeregnDatoTil() {
-    return byggNettoBarnetilsynGrunnlag("beregnDatoTil");
-  }
-
-  public static BeregnNettoBarnetilsynGrunnlag byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeListe() {
-    return byggNettoBarnetilsynGrunnlag("faktiskUtgiftPeriodeListe");
-  }
-
+  // Netto barnetilsyn
   public static BeregnNettoBarnetilsynGrunnlag byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeDatoFraTil() {
     return byggNettoBarnetilsynGrunnlag("faktiskUtgiftPeriodeDatoFraTil");
   }
@@ -120,28 +167,10 @@ public class TestUtil {
     return byggNettoBarnetilsynGrunnlag("faktiskUtgiftBelop");
   }
 
+
+  //Underholdskostnad
   public static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlag() {
     return byggUnderholdskostnadGrunnlag("");
-  }
-
-  public static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlagUtenBeregnDatoFra() {
-    return byggUnderholdskostnadGrunnlag("beregnDatoFra");
-  }
-
-  public static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlagUtenBeregnDatoTil() {
-    return byggUnderholdskostnadGrunnlag("beregnDatoTil");
-  }
-
-  public static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlagUtenSoknadBarnFodselsdato() {
-    return byggUnderholdskostnadGrunnlag("soknadBarnFodselsdato");
-  }
-
-  public static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeListe() {
-    return byggUnderholdskostnadGrunnlag("barnetilsynMedStonadPeriodeListe");
-  }
-
-  public static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeListe() {
-    return byggUnderholdskostnadGrunnlag("forpleiningUtgiftPeriodeListe");
   }
 
   public static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeDatoFraTil() {
@@ -180,20 +209,10 @@ public class TestUtil {
     return byggUnderholdskostnadGrunnlag("forpleiningUtgiftBelop");
   }
 
+
+  //BPs andel underholdskostnad
   public static BeregnBPsAndelUnderholdskostnadGrunnlag byggBPsAndelUnderholdskostnadGrunnlag() {
     return byggBPsAndelUnderholdskostnadGrunnlag("");
-  }
-
-  public static BeregnBPsAndelUnderholdskostnadGrunnlag byggBPsAndelUnderholdskostnadGrunnlagUtenBeregnDatoFra() {
-    return byggBPsAndelUnderholdskostnadGrunnlag("beregnDatoFra");
-  }
-
-  public static BeregnBPsAndelUnderholdskostnadGrunnlag byggBPsAndelUnderholdskostnadGrunnlagUtenBeregnDatoTil() {
-    return byggBPsAndelUnderholdskostnadGrunnlag("beregnDatoTil");
-  }
-
-  public static BeregnBPsAndelUnderholdskostnadGrunnlag byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeListe() {
-    return byggBPsAndelUnderholdskostnadGrunnlag("inntekterPeriodeListe");
   }
 
   public static BeregnBPsAndelUnderholdskostnadGrunnlag byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeDatoFraTil() {
@@ -220,24 +239,10 @@ public class TestUtil {
     return byggBPsAndelUnderholdskostnadGrunnlag("inntektBB");
   }
 
+
+  // Samværsfradrag
   public static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlag() {
     return byggSamvaersfradragGrunnlag("");
-  }
-
-  public static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlagUtenBeregnDatoFra() {
-    return byggSamvaersfradragGrunnlag("beregnDatoFra");
-  }
-
-  public static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlagUtenBeregnDatoTil() {
-    return byggSamvaersfradragGrunnlag("beregnDatoTil");
-  }
-
-  public static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlagUtenSoknadsbarnFodselsdato() {
-    return byggSamvaersfradragGrunnlag("soknadsbarnFodselsdato");
-  }
-
-  public static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeListe() {
-    return byggSamvaersfradragGrunnlag("samvaersklassePeriodeListe");
   }
 
   public static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeDatoFraTil() {
@@ -255,6 +260,33 @@ public class TestUtil {
   public static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlagUtenSamvaersklasse() {
     return byggSamvaersfradragGrunnlag("samvaersklasse");
   }
+
+
+  // Bygger opp BeregnBarnebidragGrunnlag (felles grunnlag for alle delberegninger)
+  private static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlag(String nullVerdi) {
+    return byggBarnebidragGrunnlag(nullVerdi, "", "", "", "", "");
+  }
+
+  private static BeregnBarnebidragGrunnlag byggBarnebidragGrunnlag(String nullVerdi, String bidragsevneVerdi, String nettoBarnetilsynVerdi,
+      String underholdskostnadVerdi, String bpAndelUnderholdskostnadVerdi, String samvaersfradragVerdi) {
+    var beregnDatoFra = (nullVerdi.equals("beregnDatoFra") ? null : LocalDate.parse("2017-01-01"));
+    var beregnDatoTil = (nullVerdi.equals("beregnDatoTil") ? null : LocalDate.parse("2020-01-01"));
+    var soknadBarnFodselsdato = (nullVerdi.equals("soknadBarnFodselsdato") ? null : LocalDate.parse("2010-01-01"));
+    var soknadBarnPersonId = (nullVerdi.equals("soknadBarnPersonId") ? null : 1);
+    var beregnBidragsevneGrunnlag = (nullVerdi.equals("beregnBidragsevneGrunnlag") ? null : byggBidragsevneGrunnlag(bidragsevneVerdi));
+    var beregnNettoBarnetilsynGrunnlag = (nullVerdi.equals("beregnNettoBarnetilsynGrunnlag") ? null
+        : byggNettoBarnetilsynGrunnlag(nettoBarnetilsynVerdi));
+    var beregnUnderholdskostnadGrunnlag = (nullVerdi.equals("beregnUnderholdskostnadGrunnlag") ? null
+        : byggUnderholdskostnadGrunnlag(underholdskostnadVerdi));
+    var beregnBPAndelUnderholdskostnadGrunnlag = (nullVerdi.equals("beregnBPAndelUnderholdskostnadGrunnlag") ? null
+        : byggBPsAndelUnderholdskostnadGrunnlag(bpAndelUnderholdskostnadVerdi));
+    var beregnSamvaersfradragGrunnlag = (nullVerdi.equals("beregnSamvaersfradragGrunnlag") ? null
+        : byggSamvaersfradragGrunnlag(samvaersfradragVerdi));
+
+    return new BeregnBarnebidragGrunnlag(beregnDatoFra, beregnDatoTil, soknadBarnFodselsdato, soknadBarnPersonId, beregnBidragsevneGrunnlag,
+        beregnNettoBarnetilsynGrunnlag, beregnUnderholdskostnadGrunnlag, beregnBPAndelUnderholdskostnadGrunnlag, beregnSamvaersfradragGrunnlag);
+  }
+
 
   // Bygger opp BeregnBidragsevneGrunnlag
   private static BeregnBidragsevneGrunnlag byggBidragsevneGrunnlag(String nullVerdi) {
@@ -352,10 +384,9 @@ public class TestUtil {
         antallBarnIEgetHusholdPeriodeListe, saerfradragPeriodeListe);
   }
 
+
   // Bygger opp NettoBarnetilsynGrunnlag
   private static BeregnNettoBarnetilsynGrunnlag byggNettoBarnetilsynGrunnlag(String nullVerdi) {
-    var beregnDatoFra = (nullVerdi.equals("beregnDatoFra") ? null : LocalDate.parse("2017-01-01"));
-    var beregnDatoTil = (nullVerdi.equals("beregnDatoTil") ? null : LocalDate.parse("2020-01-01"));
     var faktiskUtgiftPeriodeDatoFra = (nullVerdi.equals("faktiskUtgiftPeriodeDatoFra") ? null : LocalDate.parse("2017-01-01"));
     var faktiskUtgiftPeriodeDatoTil = (nullVerdi.equals("faktiskUtgiftPeriodeDatoTil") ? null : LocalDate.parse("2020-01-01"));
     var faktiskUtgiftSoknadsbarnFodselsdato = (nullVerdi.equals("faktiskUtgiftSoknadsbarnFodselsdato") ? null : LocalDate.parse("2010-01-01"));
@@ -378,14 +409,12 @@ public class TestUtil {
       faktiskUtgiftPeriodeListe.add(faktiskUtgiftPeriode);
     }
 
-    return new BeregnNettoBarnetilsynGrunnlag(beregnDatoFra, beregnDatoTil, faktiskUtgiftPeriodeListe);
+    return new BeregnNettoBarnetilsynGrunnlag(faktiskUtgiftPeriodeListe);
   }
+
 
   // Bygger opp BeregnUnderholdskostnadGrunnlag
   private static BeregnUnderholdskostnadGrunnlag byggUnderholdskostnadGrunnlag(String nullVerdi) {
-    var beregnDatoFra = (nullVerdi.equals("beregnDatoFra") ? null : LocalDate.parse("2017-01-01"));
-    var beregnDatoTil = (nullVerdi.equals("beregnDatoTil") ? null : LocalDate.parse("2020-01-01"));
-    var soknadBarnFodselsdato = (nullVerdi.equals("soknadBarnFodselsdato") ? null : LocalDate.parse("2010-01-01"));
     var barnetilsynMedStonadPeriodeDatoFra = (nullVerdi.equals("barnetilsynMedStonadPeriodeDatoFra") ? null : LocalDate.parse("2017-01-01"));
     var barnetilsynMedStonadPeriodeDatoTil = (nullVerdi.equals("barnetilsynMedStonadPeriodeDatoTil") ? null : LocalDate.parse("2020-01-01"));
     var barnetilsynMedStonadTilsynType = (nullVerdi.equals("barnetilsynMedStonadTilsynType") ? null : "DO");
@@ -424,14 +453,12 @@ public class TestUtil {
       forpleiningUtgiftPeriodeListe.add(forpleiningUtgiftPeriode);
     }
 
-    return new BeregnUnderholdskostnadGrunnlag(beregnDatoFra, beregnDatoTil, soknadBarnFodselsdato, barnetilsynMedStonadPeriodeListe,
-        forpleiningUtgiftPeriodeListe);
+    return new BeregnUnderholdskostnadGrunnlag(barnetilsynMedStonadPeriodeListe, forpleiningUtgiftPeriodeListe);
   }
+
 
   // Bygger opp BeregnBPsAndelUnderholdskostnadGrunnlag
   private static BeregnBPsAndelUnderholdskostnadGrunnlag byggBPsAndelUnderholdskostnadGrunnlag(String nullVerdi) {
-    var beregnDatoFra = (nullVerdi.equals("beregnDatoFra") ? null : LocalDate.parse("2017-01-01"));
-    var beregnDatoTil = (nullVerdi.equals("beregnDatoTil") ? null : LocalDate.parse("2020-01-01"));
     var inntekterPeriodeDatoFra = (nullVerdi.equals("inntekterPeriodeDatoFra") ? null : LocalDate.parse("2017-01-01"));
     var inntekterPeriodeDatoTil = (nullVerdi.equals("inntekterPeriodeDatoTil") ? null : LocalDate.parse("2020-01-01"));
     var inntektBP = (nullVerdi.equals("inntektBP") ? null : 100000d);
@@ -452,14 +479,12 @@ public class TestUtil {
       inntekterPeriodeListe.add(inntekterPeriode);
     }
 
-    return new BeregnBPsAndelUnderholdskostnadGrunnlag(beregnDatoFra, beregnDatoTil, inntekterPeriodeListe);
+    return new BeregnBPsAndelUnderholdskostnadGrunnlag(inntekterPeriodeListe);
   }
 
-  // Bygger opp Samværsfradrag
+
+  // Bygger opp BeregnSamvaersfradragGrunnlag
   private static BeregnSamvaersfradragGrunnlag byggSamvaersfradragGrunnlag(String nullVerdi) {
-    var beregnDatoFra = (nullVerdi.equals("beregnDatoFra") ? null : LocalDate.parse("2017-01-01"));
-    var beregnDatoTil = (nullVerdi.equals("beregnDatoTil") ? null : LocalDate.parse("2020-01-01"));
-    var soknadsbarnFodselsdato = (nullVerdi.equals("soknadsbarnFodselsdato") ? null : LocalDate.parse("2017-01-01"));
     var samvaersklassePeriodeDatoFra = (nullVerdi.equals("samvaersklassePeriodeDatoFra") ? null : LocalDate.parse("2017-01-01"));
     var samvaersklassePeriodeDatoTil = (nullVerdi.equals("samvaersklassePeriodeDatoTil") ? null : LocalDate.parse("2020-01-01"));
     var samvaersklasse = (nullVerdi.equals("samvaersklasse") ? null : "00");
@@ -479,8 +504,9 @@ public class TestUtil {
       samvaersklassePeriodeListe.add(samvaersklassePeriode);
     }
 
-    return new BeregnSamvaersfradragGrunnlag(beregnDatoFra, beregnDatoTil, soknadsbarnFodselsdato, samvaersklassePeriodeListe);
+    return new BeregnSamvaersfradragGrunnlag(samvaersklassePeriodeListe);
   }
+
 
   // Bygger opp BeregnBidragsevneResultat
   public static BeregnBidragsevneResultat dummyBidragsevneResultat() {
@@ -493,13 +519,15 @@ public class TestUtil {
     return new BeregnBidragsevneResultat(bidragPeriodeResultatListe);
   }
 
+
   // Bygger opp BeregnNettoBarnetilsynResultat
   public static BeregnNettoBarnetilsynResultat dummyNettoBarnetilsynResultat() {
     var bidragPeriodeResultatListe = new ArrayList<ResultatPeriodeNettoBarnetilsyn>();
     bidragPeriodeResultatListe.add(new ResultatPeriodeNettoBarnetilsyn(new Periode(LocalDate.parse("2017-01-01"), LocalDate.parse("2019-01-01")),
         singletonList(new ResultatBeregningNettoBarnetilsyn(1, 100)),
-        new ResultatGrunnlagNettoBarnetilsyn(singletonList(new ResultatGrunnlagFaktiskUtgift(LocalDate.parse("2010-01-01"), 1, 100d)),
-            emptyList())));
+//        new ResultatGrunnlagNettoBarnetilsyn(singletonList(new ResultatGrunnlagFaktiskUtgift(LocalDate.parse("2010-01-01"), 1, 100d)),
+//            emptyList())));
+        new ResultatGrunnlagNettoBarnetilsyn(singletonList(new ResultatGrunnlagFaktiskUtgift(LocalDate.parse("2010-01-01"), 1, 100d)))));
     return new BeregnNettoBarnetilsynResultat(bidragPeriodeResultatListe);
   }
 
@@ -524,12 +552,14 @@ public class TestUtil {
     return new BeregnNettoBarnetilsynResultatCore(emptyList(), avvikListe);
   }
 
+
   // Bygger opp BeregnUnderholdskostnadResultat
   public static BeregnUnderholdskostnadResultat dummyUnderholdskostnadResultat() {
     var bidragPeriodeResultatListe = new ArrayList<ResultatPeriodeUnderholdskostnad>();
     bidragPeriodeResultatListe.add(new ResultatPeriodeUnderholdskostnad(new Periode(LocalDate.parse("2017-01-01"), LocalDate.parse("2019-01-01")),
         new ResultatBeregningUnderholdskostnad(100d),
-        new ResultatGrunnlagUnderholdskostnad(9, "DO", "64", 1000d, 1000d, emptyList())));
+//        new ResultatGrunnlagUnderholdskostnad(9, "DO", "64", 1000d, 1000d, emptyList())));
+        new ResultatGrunnlagUnderholdskostnad(9, "DO", "64", 1000d, 1000d)));
     return new BeregnUnderholdskostnadResultat(bidragPeriodeResultatListe);
   }
 
@@ -553,13 +583,15 @@ public class TestUtil {
     return new BeregnUnderholdskostnadResultatCore(emptyList(), avvikListe);
   }
 
+
   // Bygger opp BeregnBPsAndelUnderholdskostnadResultat
   public static BeregnBPsAndelUnderholdskostnadResultat dummyBPsAndelUnderholdskostnadResultat() {
     var bidragPeriodeResultatListe = new ArrayList<ResultatPeriodeBPsAndelUnderholdskostnad>();
     bidragPeriodeResultatListe
         .add(new ResultatPeriodeBPsAndelUnderholdskostnad(new Periode(LocalDate.parse("2017-01-01"), LocalDate.parse("2019-01-01")),
             new ResultatBeregningBPsAndelUnderholdskostnad(10d),
-            new ResultatGrunnlagBPsAndelUnderholdskostnad(100000d, 100000d, 100000d, emptyList())));
+//            new ResultatGrunnlagBPsAndelUnderholdskostnad(100000d, 100000d, 100000d, emptyList())));
+            new ResultatGrunnlagBPsAndelUnderholdskostnad(100000d, 100000d, 100000d)));
     return new BeregnBPsAndelUnderholdskostnadResultat(bidragPeriodeResultatListe);
   }
 
@@ -583,12 +615,14 @@ public class TestUtil {
     return new BeregnBPsAndelUnderholdskostnadResultatCore(emptyList(), avvikListe);
   }
 
+
   // Bygger opp BeregnSamvaersfradragResultat
   public static BeregnSamvaersfradragResultat dummySamvaersfradragResultat() {
     var bidragPeriodeResultatListe = new ArrayList<ResultatPeriodeSamvaersfradrag>();
     bidragPeriodeResultatListe.add(new ResultatPeriodeSamvaersfradrag(new Periode(LocalDate.parse("2017-01-01"), LocalDate.parse("2019-01-01")),
         new ResultatBeregningSamvaersfradrag(100d),
-        new ResultatGrunnlagSamvaersfradrag(9, "00", emptyList())));
+        new ResultatGrunnlagSamvaersfradrag(9, "00")));
+//        new ResultatGrunnlagSamvaersfradrag(9, "00", emptyList())));
     return new BeregnSamvaersfradragResultat(bidragPeriodeResultatListe);
   }
 
@@ -611,6 +645,7 @@ public class TestUtil {
         "DATO_FRA_ETTER_DATO_TIL"));
     return new BeregnSamvaersfradragResultatCore(emptyList(), avvikListe);
   }
+
 
   // Bygger opp BeregnKostnadsberegnetBidragResultat
   public static BeregnKostnadsberegnetBidragResultat dummyKostnadsberegnetBidragResultat() {
@@ -641,6 +676,7 @@ public class TestUtil {
         "DATO_FRA_ETTER_DATO_TIL"));
     return new BeregnKostnadsberegnetBidragResultatCore(emptyList(), avvikListe);
   }
+
 
   // Bygger opp liste av sjabloner av typen Sjablontall
   public static List<Sjablontall> dummySjablonSjablontallListe() {

--- a/src/test/java/no/nav/bidrag/beregn/barnebidrag/rest/dto/DtoTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/barnebidrag/rest/dto/DtoTest.java
@@ -10,102 +10,92 @@ import org.junit.jupiter.api.Test;
 @DisplayName("DtoTest")
 class DtoTest {
 
-  // Netto barnetilsyn
+  // Barnebidrag
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når beregnDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarNBBeregnDatoFraErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenBeregnDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoFra kan ikke være null");
+  void skalKasteIllegalArgumentExceptionNaarBBBeregnDatoFraErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenBeregnDatoFra();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("beregnDatoFra kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når beregnDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarNBBeregnDatoTilErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenBeregnDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoTil kan ikke være null");
+  void skalKasteIllegalArgumentExceptionNaarBBBeregnDatoTilErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenBeregnDatoTil();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("beregnDatoTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når soknadBarnFodselsdato er null")
+  void skalKasteIllegalArgumentExceptionNaarBBSoknadBarnFodselsdatoErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenSoknadBarnFodselsdato();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("soknadBarnFodselsdato kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når soknadBarnPersonId er null")
+  void skalKasteIllegalArgumentExceptionNaarBBSoknadBarnPersonIdErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenSoknadBarnPersonId();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("soknadBarnPersonId kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når beregnBidragsevneGrunnlag er null")
+  void skalKasteIllegalArgumentExceptionNaarBBBeregnBidragsevneGrunnlagErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenBeregnBidragsevneGrunnlag();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("beregnBidragsevneGrunnlag kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når beregnNettoBarnetilsynGrunnlag er null")
+  void skalKasteIllegalArgumentExceptionNaarBBBeregnNettoBarnetilsynGrunnlagErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenBeregnNettoBarnetilsynGrunnlag();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("beregnNettoBarnetilsynGrunnlag kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når beregnUnderholdskostnadGrunnlag er null")
+  void skalKasteIllegalArgumentExceptionNaarBBBeregnUnderholdskostnadGrunnlagErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenBeregnUnderholdskostnadGrunnlag();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("beregnUnderholdskostnadGrunnlag kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når beregnBPAndelUnderholdskostnadGrunnlag er null")
+  void skalKasteIllegalArgumentExceptionNaarBBBeregnBPAndelUnderholdskostnadGrunnlagErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenBeregnBPAndelUnderholdskostnadGrunnlag();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("beregnBPAndelUnderholdskostnadGrunnlag kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når beregnSamvaersfradragGrunnlag er null")
+  void skalKasteIllegalArgumentExceptionNaarBBBeregnSamvaersfradragGrunnlagErNull() {
+    var grunnlag = TestUtil.byggBarnebidragGrunnlagUtenBeregnSamvaersfradragGrunnlag();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::validerBarnebidragGrunnlag)
+        .withMessage("beregnSamvaersfradragGrunnlag kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftPeriodeListe er null")
   void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftPeriodeListeErNull() {
     var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeListe();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("faktiskUtgiftPeriodeListe kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftPeriodeDatoFraTil er null")
-  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftPeriodeDatoFraTilErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeDatoFraTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("faktiskUtgiftPeriodeDatoFraTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftPeriodeDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftPeriodeDatoFraErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("periodeDatoFra kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftPeriodeDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftPeriodeDatoTilErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("periodeDatoTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftSoknadsbarnFodselsdato er null")
-  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftSoknadsbarnFodselsdatoErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftSoknadsbarnFodselsdato();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("faktiskUtgiftSoknadsbarnFodselsdato kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftSoknadsbarnPersonId er null")
-  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftSoknadsbarnPersonIdErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftSoknadsbarnPersonId();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("faktiskUtgiftSoknadsbarnPersonId kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftBelop er null")
-  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftBelopErNull() {
-    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftBelop();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("faktiskUtgiftBelop kan ikke være null");
-  }
-
-  // Underholdskostnad
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når beregnDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarUKBeregnDatoFraErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBeregnDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoFra kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når beregnDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarUKBeregnDatoTilErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBeregnDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når soknadBarnFodselsdato er null")
-  void skalKasteIllegalArgumentExceptionNaarUKSoknadBarnFodselsdatoErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenSoknadBarnFodselsdato();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("soknadBarnFodselsdato kan ikke være null");
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::nettoBarnetilsynTilCore)
+        .withMessage("faktiskUtgiftPeriodeListe kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadPeriodeListe er null")
   void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadPeriodeListeErNull() {
     var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeListe();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::underholdskostnadTilCore)
         .withMessage("barnetilsynMedStonadPeriodeListe kan ikke være null");
   }
 
@@ -113,203 +103,223 @@ class DtoTest {
   @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftPeriodeListe er null")
   void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftPeriodeListeErNull() {
     var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeListe();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::underholdskostnadTilCore)
         .withMessage("forpleiningUtgiftPeriodeListe kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadPeriodeDatoFraTil er null")
-  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadPeriodeDatoFraTilErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeDatoFraTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("barnetilsynMedStonadPeriodeDatoFraTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadPeriodeDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadPeriodeDatoFraErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("periodeDatoFra kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadPeriodeDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadPeriodeDatoTilErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("periodeDatoTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadTilsynType er null")
-  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadTilsynTypeErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadTilsynType();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("barnetilsynMedStonadTilsynType kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadStonadType er null")
-  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadStonadTypeErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadStonadType();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("barnetilsynMedStonadStonadType kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftPeriodeDatoFraTil er null")
-  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftPeriodeDatoFraTilErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeDatoFraTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("forpleiningUtgiftPeriodeDatoFraTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftPeriodeDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftPeriodeDatoFraErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("periodeDatoFra kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftPeriodeDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftPeriodeDatoTilErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("periodeDatoTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftBelop er null")
-  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftBelopErNull() {
-    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftBelop();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("forpleiningUtgiftBelop kan ikke være null");
-  }
-
-  // BPs andel av underholdskostnad
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når beregnDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKBeregnDatoFraErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenBeregnDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoFra kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når beregnDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKBeregnDatoTilErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenBeregnDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoTil kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når inntekterPeriodeListe er null")
   void skalKasteIllegalArgumentExceptionNaarBPUKInntekterPeriodeListeErNull() {
     var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeListe();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::bpAndelUnderholdskostnadTilCore)
         .withMessage("inntekterPeriodeListe kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når inntekterPeriodeDatoFraTil er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKInntekterPeriodeDatoFraTilErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeDatoFraTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("inntekterPeriodeDatoFraTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når inntekterPeriodeDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKInntekterPeriodeDatoFraErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("periodeDatoFra kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når inntekterPeriodeDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKInntekterPeriodeDatoTilErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("periodeDatoTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når inntektBP er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKInntektBPErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntektBP();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("inntektBP kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når inntektBM er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKInntektBMErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntektBM();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("inntektBM kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når inntektBB er null")
-  void skalKasteIllegalArgumentExceptionNaarBPUKInntektBBErNull() {
-    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntektBB();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
-        .withMessage("inntektBB kan ikke være null");
-  }
-
-  // Samværsfradrag
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når beregnDatoFra er null")
-  void skalKasteIllegalArgumentExceptionNaarSFBeregnDatoFraErNull() {
-    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenBeregnDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoFra kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når beregnDatoTil er null")
-  void skalKasteIllegalArgumentExceptionNaarSFBeregnDatoTilErNull() {
-    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenBeregnDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("beregnDatoTil kan ikke være null");
-  }
-
-  @Test
-  @DisplayName("Skal kaste IllegalArgumentException når soknadsbarnFodselsdato er null")
-  void skalKasteIllegalArgumentExceptionNaarSFSoknadsbarnFodselsdatoErNull() {
-    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSoknadsbarnFodselsdato();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("soknadsbarnFodselsdato kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når samvaersklassePeriodeListe er null")
   void skalKasteIllegalArgumentExceptionNaarSFSamvaersklassePeriodeListeErNull() {
     var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeListe();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("samvaersklassePeriodeListe kan ikke være null");
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::samvaersfradragTilCore)
+        .withMessage("samvaersklassePeriodeListe kan ikke være null");
+  }
+
+
+  // Netto barnetilsyn
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftPeriodeDatoFraTil er null")
+  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftPeriodeDatoFraTilErNull() {
+    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeDatoFraTil().getFaktiskUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("faktiskUtgiftPeriodeDatoFraTil kan ikke være null");
   }
 
   @Test
+  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftPeriodeDatoFra er null")
+  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftPeriodeDatoFraErNull() {
+    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeDatoFra().getFaktiskUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("periodeDatoFra kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftPeriodeDatoTil er null")
+  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftPeriodeDatoTilErNull() {
+    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftPeriodeDatoTil().getFaktiskUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("periodeDatoTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftSoknadsbarnFodselsdato er null")
+  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftSoknadsbarnFodselsdatoErNull() {
+    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftSoknadsbarnFodselsdato().getFaktiskUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("faktiskUtgiftSoknadsbarnFodselsdato kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftSoknadsbarnPersonId er null")
+  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftSoknadsbarnPersonIdErNull() {
+    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftSoknadsbarnPersonId().getFaktiskUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("faktiskUtgiftSoknadsbarnPersonId kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når faktiskUtgiftBelop er null")
+  void skalKasteIllegalArgumentExceptionNaarNBFaktiskUtgiftBelopErNull() {
+    var grunnlag = TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftBelop().getFaktiskUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("faktiskUtgiftBelop kan ikke være null");
+  }
+
+
+  // Underholdskostnad
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadPeriodeDatoFraTil er null")
+  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadPeriodeDatoFraTilErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeDatoFraTil().getBarnetilsynMedStonadPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("barnetilsynMedStonadPeriodeDatoFraTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadPeriodeDatoFra er null")
+  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadPeriodeDatoFraErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeDatoFra().getBarnetilsynMedStonadPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("periodeDatoFra kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadPeriodeDatoTil er null")
+  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadPeriodeDatoTilErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadPeriodeDatoTil().getBarnetilsynMedStonadPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("periodeDatoTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadTilsynType er null")
+  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadTilsynTypeErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadTilsynType().getBarnetilsynMedStonadPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("barnetilsynMedStonadTilsynType kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når barnetilsynMedStonadStonadType er null")
+  void skalKasteIllegalArgumentExceptionNaarUKBarnetilsynMedStonadStonadTypeErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenBarnetilsynMedStonadStonadType().getBarnetilsynMedStonadPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("barnetilsynMedStonadStonadType kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftPeriodeDatoFraTil er null")
+  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftPeriodeDatoFraTilErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeDatoFraTil().getForpleiningUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("forpleiningUtgiftPeriodeDatoFraTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftPeriodeDatoFra er null")
+  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftPeriodeDatoFraErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeDatoFra().getForpleiningUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("periodeDatoFra kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftPeriodeDatoTil er null")
+  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftPeriodeDatoTilErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftPeriodeDatoTil().getForpleiningUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("periodeDatoTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når forpleiningUtgiftBelop er null")
+  void skalKasteIllegalArgumentExceptionNaarUKForpleiningUtgiftBelopErNull() {
+    var grunnlag = TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftBelop().getForpleiningUtgiftPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("forpleiningUtgiftBelop kan ikke være null");
+  }
+
+
+  // BPs andel av underholdskostnad
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når inntekterPeriodeDatoFraTil er null")
+  void skalKasteIllegalArgumentExceptionNaarBPUKInntekterPeriodeDatoFraTilErNull() {
+    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeDatoFraTil().getInntekterPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("inntekterPeriodeDatoFraTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når inntekterPeriodeDatoFra er null")
+  void skalKasteIllegalArgumentExceptionNaarBPUKInntekterPeriodeDatoFraErNull() {
+    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeDatoFra().getInntekterPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("periodeDatoFra kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når inntekterPeriodeDatoTil er null")
+  void skalKasteIllegalArgumentExceptionNaarBPUKInntekterPeriodeDatoTilErNull() {
+    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntekterPeriodeDatoTil().getInntekterPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("periodeDatoTil kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når inntektBP er null")
+  void skalKasteIllegalArgumentExceptionNaarBPUKInntektBPErNull() {
+    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntektBP().getInntekterPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("inntektBP kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når inntektBM er null")
+  void skalKasteIllegalArgumentExceptionNaarBPUKInntektBMErNull() {
+    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntektBM().getInntekterPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("inntektBM kan ikke være null");
+  }
+
+  @Test
+  @DisplayName("Skal kaste IllegalArgumentException når inntektBB er null")
+  void skalKasteIllegalArgumentExceptionNaarBPUKInntektBBErNull() {
+    var grunnlag = TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntektBB().getInntekterPeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
+        .withMessage("inntektBB kan ikke være null");
+  }
+
+
+  // Samværsfradrag
+  @Test
   @DisplayName("Skal kaste IllegalArgumentException når samvaersklassePeriodeDatoFraTil er null")
   void skalKasteIllegalArgumentExceptionNaarSFSamvaersklassePeriodeDatoFraTilErNull() {
-    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeDatoFraTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore)
+    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeDatoFraTil().getSamvaersklassePeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore)
         .withMessage("samvaersklassePeriodeDatoFraTil kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når samvaersklassePeriodeDatoFra er null")
   void skalKasteIllegalArgumentExceptionNaarSFSamvaersklassePeriodeDatoFraErNull() {
-    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeDatoFra();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("periodeDatoFra kan ikke være null");
+    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeDatoFra().getSamvaersklassePeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("periodeDatoFra kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når samvaersklassePeriodeDatoTil er null")
   void skalKasteIllegalArgumentExceptionNaarSFSamvaersklassePeriodeDatoTilErNull() {
-    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeDatoTil();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("periodeDatoTil kan ikke være null");
+    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklassePeriodeDatoTil().getSamvaersklassePeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("periodeDatoTil kan ikke være null");
   }
 
   @Test
   @DisplayName("Skal kaste IllegalArgumentException når samvaersklasse er null")
   void skalKasteIllegalArgumentExceptionNaarSFSamvaersklasseErNull() {
-    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklasse();
-    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag::tilCore).withMessage("samvaersklasse kan ikke være null");
+    var grunnlag = TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklasse().getSamvaersklassePeriodeListe();
+    assertThatExceptionOfType(UgyldigInputException.class).isThrownBy(grunnlag.get(0)::tilCore).withMessage("samvaersklasse kan ikke være null");
   }
 }

--- a/src/test/java/no/nav/bidrag/beregn/barnebidrag/rest/service/BeregnBarnebidragServiceTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/barnebidrag/rest/service/BeregnBarnebidragServiceTest.java
@@ -335,7 +335,8 @@ class BeregnBarnebidragServiceTest {
   void skalKasteUgyldigInputExceptionVedValideringAvInputdataNettoBarnetilsyn() {
     assertThatExceptionOfType(UgyldigInputException.class)
         .isThrownBy(() -> beregnBarnebidragService.beregn(
-            new BeregnBarnebidragGrunnlag(TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftBelop(),
+            new BeregnBarnebidragGrunnlag(LocalDate.parse("2017-01-01"), LocalDate.parse("2020-01-01"), LocalDate.parse("2010-01-01"), 1,
+                TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlagUtenFaktiskUtgiftBelop(),
                 TestUtil.byggUnderholdskostnadGrunnlag(), TestUtil.byggBPsAndelUnderholdskostnadGrunnlag(), TestUtil.byggSamvaersfradragGrunnlag())))
         .withMessageContaining("faktiskUtgiftBelop kan ikke være null");
   }
@@ -345,10 +346,10 @@ class BeregnBarnebidragServiceTest {
   void skalKasteUgyldigInputExceptionVedValideringAvInputdataUnderholdskostnad() {
     assertThatExceptionOfType(UgyldigInputException.class)
         .isThrownBy(() -> beregnBarnebidragService.beregn(
-            new BeregnBarnebidragGrunnlag(TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlag(),
-                TestUtil.byggUnderholdskostnadGrunnlagUtenSoknadBarnFodselsdato(), TestUtil.byggBPsAndelUnderholdskostnadGrunnlag(),
+            new BeregnBarnebidragGrunnlag(LocalDate.parse("2017-01-01"), LocalDate.parse("2020-01-01"), LocalDate.parse("2010-01-01"), 1, TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlag(),
+                TestUtil.byggUnderholdskostnadGrunnlagUtenForpleiningUtgiftBelop(), TestUtil.byggBPsAndelUnderholdskostnadGrunnlag(),
                 TestUtil.byggSamvaersfradragGrunnlag())))
-        .withMessageContaining("soknadBarnFodselsdato kan ikke være null");
+        .withMessageContaining("forpleiningUtgiftBelop kan ikke være null");
   }
 
   @Test
@@ -356,7 +357,8 @@ class BeregnBarnebidragServiceTest {
   void skalKasteUgyldigInputExceptionVedValideringAvInputdataBPsAndelUnderholdskostnad() {
     assertThatExceptionOfType(UgyldigInputException.class)
         .isThrownBy(() -> beregnBarnebidragService.beregn(
-            new BeregnBarnebidragGrunnlag(TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlag(),
+            new BeregnBarnebidragGrunnlag(LocalDate.parse("2017-01-01"), LocalDate.parse("2020-01-01"), LocalDate.parse("2010-01-01"), 1,
+                TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlag(),
                 TestUtil.byggUnderholdskostnadGrunnlag(), TestUtil.byggBPsAndelUnderholdskostnadGrunnlagUtenInntektBP(),
                 TestUtil.byggSamvaersfradragGrunnlag())))
         .withMessageContaining("inntektBP kan ikke være null");
@@ -367,9 +369,10 @@ class BeregnBarnebidragServiceTest {
   void skalKasteUgyldigInputExceptionVedValideringAvInputdataSamvaersfradrag() {
     assertThatExceptionOfType(UgyldigInputException.class)
         .isThrownBy(() -> beregnBarnebidragService.beregn(
-            new BeregnBarnebidragGrunnlag(TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlag(),
+            new BeregnBarnebidragGrunnlag(LocalDate.parse("2017-01-01"), LocalDate.parse("2020-01-01"), LocalDate.parse("2010-01-01"), 1,
+                TestUtil.byggBidragsevneGrunnlag(), TestUtil.byggNettoBarnetilsynGrunnlag(),
                 TestUtil.byggUnderholdskostnadGrunnlag(), TestUtil.byggBPsAndelUnderholdskostnadGrunnlag(),
-                TestUtil.byggSamvaersfradragGrunnlagUtenSoknadsbarnFodselsdato())))
-        .withMessageContaining("soknadsbarnFodselsdato kan ikke være null");
+                TestUtil.byggSamvaersfradragGrunnlagUtenSamvaersklasse())))
+        .withMessageContaining("samvaersklasse kan ikke være null");
   }
 }


### PR DESCRIPTION
- Midlertidig fjernet sjabloner fra resultatgrunnlaget som legges ut
- Resultatet fra beregning av netto barnetilsyn skal inngå i inputen til beregning av underholdskostnad
- Riktig fra- og til-dato i input'en til beregning av kostnadsberegnet bidrag